### PR TITLE
Add HMS integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
         google()
         jcenter()
         mavenCentral()
+        maven { url 'https://developer.huawei.com/repo/' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'
@@ -24,6 +25,7 @@ allprojects {
         google()
         jcenter()
         mavenCentral()
+        maven { url 'https://developer.huawei.com/repo/' }
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -17,11 +17,11 @@ jacoco {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 30
+        minSdkVersion 19
+        targetSdkVersion 31
         versionCode 1
         versionName "1.1.0"
     }
@@ -51,6 +51,7 @@ dependencies {
     api fileTree(dir: 'libs', include: ['*.jar'])
 
     api 'com.google.android.gms:play-services-location:18.0.0'
+    api 'com.huawei.hms:location:6.0.0.302'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.10"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0"

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,5 +1,12 @@
-<manifest package="com.patloew.colocation">
+<manifest package="com.patloew.colocation"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application />
+
+    <queries>
+        <intent>
+            <action android:name="com.huawei.hms.core.aidlservice" />
+        </intent>
+    </queries>
 
 </manifest>

--- a/library/src/main/java/com/patloew/colocation/CoLocationHms.kt
+++ b/library/src/main/java/com/patloew/colocation/CoLocationHms.kt
@@ -1,0 +1,186 @@
+package com.patloew.colocation
+
+import android.Manifest
+import android.content.Context
+import android.location.Location
+import android.os.Looper
+import androidx.annotation.RequiresPermission
+import com.huawei.hms.common.ResolvableApiException
+import com.huawei.hms.location.FusedLocationProviderClient
+import com.huawei.hms.location.LocationAvailability
+import com.huawei.hms.location.LocationCallback
+import com.huawei.hms.location.LocationResult
+import com.huawei.hms.location.LocationServices
+import com.huawei.hms.location.SettingsClient
+import com.patloew.colocation.request.LocationRequest
+import com.patloew.colocation.request.LocationSettingsRequest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/* Copyright 2020 Patrick Löwenstein
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+internal class CoLocationHms(private val context: Context) : CoLocation {
+
+    private val locationProvider: FusedLocationProviderClient by lazy {
+        LocationServices.getFusedLocationProviderClient(context)
+    }
+    private val settings: SettingsClient by lazy { LocationServices.getSettingsClient(context) }
+
+    private val cancelledMessage = "Task was cancelled"
+
+    override suspend fun flushLocations() {
+        locationProvider.flushLocations().await()
+    }
+
+    @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])
+    override suspend fun isLocationAvailable(): Boolean =
+        locationProvider.locationAvailability.await().isLocationAvailable
+
+    /**
+     * getCurrentLocation() is not available in HMS implementation
+     */
+    @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])
+    override suspend fun getCurrentLocation(priority: Int): Location? = null
+
+    @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])
+    override suspend fun getLastLocation(): Location? = locationProvider.lastLocation.await()
+
+    @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])
+    override suspend fun getLocationUpdate(locationRequest: LocationRequest): Location =
+        suspendCancellableCoroutine { cont ->
+            lateinit var callback: HmsClearableLocationCallback
+            callback = object : LocationCallback() {
+                override fun onLocationResult(result: LocationResult) {
+                    cont.resume(result.lastLocation)
+                    locationProvider.removeLocationUpdates(callback)
+                    callback.clear()
+                }
+            }.let(::HmsClearableLocationCallback) // Needed since we would have memory leaks otherwise
+
+            locationProvider.requestLocationUpdates(
+                locationRequest.toHms(),
+                callback,
+                Looper.getMainLooper()
+            ).apply {
+                addOnCanceledListener {
+                    callback.clear()
+                    cont.resumeWithException(TaskCancelledException(cancelledMessage))
+                }
+                addOnFailureListener {
+                    callback.clear()
+                    cont.resumeWithException(it)
+                }
+            }
+        }
+
+    @ExperimentalCoroutinesApi
+    @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])
+    override fun getLocationUpdates(
+        locationRequest: LocationRequest,
+        capacity: Int
+    ): Flow<Location> =
+        callbackFlow<Location> {
+            val hmsRequest = locationRequest.toHms()
+
+            val callback = object : LocationCallback() {
+                private var counter: Int = 0
+                override fun onLocationResult(result: LocationResult) {
+                    trySendBlocking(result.lastLocation)
+                    if (hmsRequest.numUpdates == ++counter) close()
+                }
+            }.let(::HmsClearableLocationCallback) // Needed since we would have memory leaks otherwise
+
+            locationProvider.requestLocationUpdates(
+                hmsRequest,
+                callback,
+                Looper.getMainLooper()
+            ).apply {
+                addOnCanceledListener {
+                    cancel(
+                        cancelledMessage,
+                        TaskCancelledException(cancelledMessage)
+                    )
+                }
+                addOnFailureListener { cancel("Error requesting location updates", it) }
+            }
+
+            awaitClose {
+                locationProvider.removeLocationUpdates(callback)
+                callback.clear()
+            }
+        }.buffer(capacity)
+
+    override suspend fun checkLocationSettings(locationSettingsRequest: LocationSettingsRequest): CoLocation.SettingsResult =
+        suspendCancellableCoroutine { cont ->
+            settings.checkLocationSettings(locationSettingsRequest.toHms())
+                .addOnSuccessListener { cont.resume(CoLocation.SettingsResult.Satisfied) }
+                .addOnCanceledListener {
+                    cont.resumeWithException(
+                        TaskCancelledException(
+                            cancelledMessage
+                        )
+                    )
+                }
+                .addOnFailureListener { exception ->
+                    if (exception is ResolvableApiException) {
+                        CoLocation.SettingsResult.Resolvable(ResolvableApiExceptionWrapper(exception))
+                    } else {
+                        CoLocation.SettingsResult.NotResolvable(exception)
+                    }.run(cont::resume)
+                }
+        }
+
+    override suspend fun checkLocationSettings(locationRequest: LocationRequest): CoLocation.SettingsResult =
+        checkLocationSettings(
+            LocationSettingsRequest.Builder().addLocationRequest(locationRequest).build()
+        )
+
+    @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])
+    override suspend fun setMockLocation(location: Location) {
+        locationProvider.setMockLocation(location).await()
+    }
+
+    @RequiresPermission(anyOf = [Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION])
+    override suspend fun setMockMode(isMockMode: Boolean) {
+        locationProvider.setMockMode(isMockMode).await()
+    }
+
+}
+
+/** Wraps [callback] so that the reference can be cleared */
+private class HmsClearableLocationCallback(callback: LocationCallback) : LocationCallback() {
+
+    private var callback: LocationCallback? = callback
+
+    override fun onLocationAvailability(locationAvailability: LocationAvailability) {
+        callback?.onLocationAvailability(locationAvailability)
+    }
+
+    override fun onLocationResult(locationResult: LocationResult) {
+        callback?.onLocationResult(locationResult)
+    }
+
+    fun clear() {
+        callback = null
+    }
+
+}

--- a/library/src/main/java/com/patloew/colocation/LocationServicesSource.kt
+++ b/library/src/main/java/com/patloew/colocation/LocationServicesSource.kt
@@ -1,0 +1,25 @@
+package com.patloew.colocation
+
+import android.content.Context
+import com.google.android.gms.common.GoogleApiAvailability
+import com.huawei.hms.api.HuaweiApiAvailability
+
+fun Context.getLocationServiceSource(): LocationServicesSource {
+    val googleApi = GoogleApiAvailability.getInstance()
+    if (googleApi.isGooglePlayServicesAvailable(this) == com.google.android.gms.common.ConnectionResult.SUCCESS) {
+        return LocationServicesSource.GMS
+    }
+
+    val huaweiApi = HuaweiApiAvailability.getInstance()
+    if (huaweiApi.isHuaweiMobileServicesAvailable(this) == com.huawei.hms.api.ConnectionResult.SUCCESS) {
+        return LocationServicesSource.HMS
+    }
+
+    return LocationServicesSource.NONE
+}
+
+enum class LocationServicesSource() {
+    GMS,
+    HMS,
+    NONE
+}

--- a/library/src/main/java/com/patloew/colocation/ResolvableApiExceptionWrapper.kt
+++ b/library/src/main/java/com/patloew/colocation/ResolvableApiExceptionWrapper.kt
@@ -1,0 +1,54 @@
+package com.patloew.colocation
+
+import android.app.Activity
+import android.app.PendingIntent
+import android.content.Intent
+import com.google.android.gms.common.api.ResolvableApiException as GmsResolvableApiException
+import com.huawei.hms.common.ResolvableApiException as HmsResolvableApiException
+
+data class ResolvableApiExceptionWrapper(
+    private val exception: Exception
+) {
+
+    init {
+        require(exception is GmsResolvableApiException || exception is HmsResolvableApiException)
+    }
+
+    fun startResolutionForResult(activity: Activity, requestCode: Int) {
+        when (exception) {
+            is GmsResolvableApiException -> {
+                exception.startResolutionForResult(activity, requestCode)
+            }
+            is HmsResolvableApiException -> {
+                exception.startResolutionForResult(activity, requestCode)
+            }
+        }
+    }
+
+    fun getResolution(): PendingIntent {
+        return when (exception) {
+            is GmsResolvableApiException -> {
+                exception.resolution
+            }
+            is HmsResolvableApiException -> {
+                exception.resolution
+            }
+            else -> throw IllegalStateException()
+        }
+    }
+
+    /**
+     * Specific for HMS
+     */
+    fun getResolutionIntent(): Intent? {
+        return when (exception) {
+            is GmsResolvableApiException -> {
+                null
+            }
+            is HmsResolvableApiException -> {
+                exception.resolutionIntent
+            }
+            else -> throw IllegalStateException()
+        }
+    }
+}

--- a/library/src/main/java/com/patloew/colocation/request/LocationRequest.kt
+++ b/library/src/main/java/com/patloew/colocation/request/LocationRequest.kt
@@ -1,0 +1,151 @@
+package com.patloew.colocation.request
+
+
+class LocationRequest {
+
+    companion object {
+        const val PRIORITY_HIGH_ACCURACY = 100
+        const val PRIORITY_BALANCED_POWER_ACCURACY = 102
+        const val PRIORITY_LOW_POWER = 104
+        const val PRIORITY_NO_POWER = 105
+
+        fun create() = LocationRequest()
+    }
+
+    private var priority: Int? = null
+    private var interval: Long? = null
+    private var fastestInterval: Long? = null
+    private var waitForAccurateLocation: Boolean? = null
+    private var expirationTime: Long? = null
+    private var numUpdates: Int? = null
+    private var smallestDisplacement: Float? = null
+    private var maxWaitTime: Long? = null
+
+    // GMS specific
+    private var expirationDuration: Long? = null
+
+    // HMS specific
+    private var needAddress: Boolean? = null
+    private var language: String? = null
+    private var countryCode: String? = null
+    private var extras: MutableMap<String, String>? = null
+
+
+    fun setExpirationDuration(millis: Long): LocationRequest {
+        this.expirationDuration = millis
+        return this
+    }
+
+    fun setExpirationTime(millis: Long): LocationRequest {
+        this.expirationTime = millis
+        return this
+    }
+
+    fun setFastestInterval(millis: Long): LocationRequest {
+        this.fastestInterval = millis
+        return this
+    }
+
+    fun setInterval(millis: Long): LocationRequest {
+        this.interval = millis
+        return this
+    }
+
+    fun setMaxWaitTime(millis: Long): LocationRequest {
+        this.maxWaitTime = millis
+        return this
+    }
+
+    fun setNumUpdates(numUpdates: Int): LocationRequest {
+        this.numUpdates = numUpdates
+        return this
+    }
+
+    fun setPriority(priority: Int): LocationRequest {
+        this.priority = priority
+        return this
+    }
+
+    fun setSmallestDisplacement(smallestDisplacementMeters: Float): LocationRequest {
+        this.smallestDisplacement = smallestDisplacementMeters
+        return this
+    }
+
+    /**
+     * GMS specific
+     */
+    fun setWaitForAccurateLocation(waitForAccurateLocation: Boolean): LocationRequest {
+        this.waitForAccurateLocation = waitForAccurateLocation
+        return this
+    }
+
+    /**
+     * HMS specific
+     */
+    fun setCountryCode(countryCode: String): LocationRequest {
+        this.countryCode = countryCode
+        return this
+    }
+
+    /**
+     * HMS specific
+     */
+    fun setNeedAddress(needAddress: Boolean): LocationRequest {
+        this.needAddress = needAddress
+        return this
+    }
+
+    /**
+     * HMS specific
+     */
+    fun setLanguage(language: String): LocationRequest {
+        this.language = language
+        return this
+    }
+
+    /**
+     * HMS specific
+     */
+    fun putExtras(key: String, value: String): LocationRequest {
+        if (this.extras == null) {
+            this.extras = mutableMapOf()
+        }
+        extras?.put(key, value)
+        return this
+    }
+
+    fun toGms(): com.google.android.gms.location.LocationRequest {
+        val request = com.google.android.gms.location.LocationRequest.create()
+        priority?.let { request.setPriority(it) }
+        interval?.let { request.setInterval(it) }
+        fastestInterval?.let { request.setFastestInterval(it) }
+        expirationTime?.let { request.setExpirationTime(it) }
+        numUpdates?.let { request.setNumUpdates(it) }
+        smallestDisplacement?.let { request.setSmallestDisplacement(it) }
+        maxWaitTime?.let { request.setMaxWaitTime(it) }
+        expirationDuration?.let { request.setExpirationDuration(it) }
+
+        // GMS specific functions
+        waitForAccurateLocation?.let { request.setWaitForAccurateLocation(it) }
+        return request
+    }
+
+    fun toHms(): com.huawei.hms.location.LocationRequest {
+        val request = com.huawei.hms.location.LocationRequest.create()
+        priority?.let { request.setPriority(it) }
+        interval?.let { request.setInterval(it) }
+        fastestInterval?.let { request.setFastestInterval(it) }
+        expirationTime?.let { request.setExpirationTime(it) }
+        numUpdates?.let { request.setNumUpdates(it) }
+        smallestDisplacement?.let { request.setSmallestDisplacement(it) }
+        maxWaitTime?.let { request.setMaxWaitTime(it) }
+        expirationDuration?.let { request.setExpirationDuration(it) }
+
+        // HMS specific functions
+        needAddress?.let { request.setNeedAddress(it) }
+        language?.let { request.setLanguage(it) }
+        countryCode?.let { request.setCountryCode(it) }
+        extras?.let { it.forEach { (k, v) -> request.putExtras(k, v) } }
+        return request
+    }
+}

--- a/library/src/main/java/com/patloew/colocation/request/LocationSettingsRequest.kt
+++ b/library/src/main/java/com/patloew/colocation/request/LocationSettingsRequest.kt
@@ -1,0 +1,53 @@
+package com.patloew.colocation.request
+
+data class LocationSettingsRequest(
+    val requests: List<LocationRequest>,
+    val alwaysShow: Boolean,
+    val needBle: Boolean
+) {
+
+    fun toGms(): com.google.android.gms.location.LocationSettingsRequest {
+        return com.google.android.gms.location.LocationSettingsRequest.Builder()
+            .addAllLocationRequests(requests.map { it.toGms() })
+            .setAlwaysShow(alwaysShow)
+            .setNeedBle(needBle)
+            .build()
+    }
+
+    fun toHms(): com.huawei.hms.location.LocationSettingsRequest {
+        return com.huawei.hms.location.LocationSettingsRequest.Builder()
+            .addAllLocationRequests(requests.map { it.toHms() })
+            .setAlwaysShow(alwaysShow)
+            .setNeedBle(needBle)
+            .build()
+    }
+
+    class Builder {
+        private val requests: MutableList<LocationRequest> = mutableListOf()
+        private var alwaysShow: Boolean = false
+        private var needBle: Boolean = false
+
+        fun addAllLocationRequests(requests: Collection<LocationRequest>): Builder {
+            this.requests.addAll(requests)
+            return this
+        }
+
+        fun addLocationRequest(request: LocationRequest): Builder {
+            this.requests.add(request)
+            return this
+        }
+
+        fun setAlwaysShow(alwaysShow: Boolean): Builder {
+            this.alwaysShow = alwaysShow
+            return this
+        }
+
+        fun setNeedBle(needBle: Boolean): Builder {
+            this.needBle = needBle
+            return this
+        }
+
+        fun build(): LocationSettingsRequest =
+            LocationSettingsRequest(requests, alwaysShow, needBle)
+    }
+}

--- a/library/src/main/java/com/patloew/colocation/util/HmsTasks.kt
+++ b/library/src/main/java/com/patloew/colocation/util/HmsTasks.kt
@@ -1,0 +1,98 @@
+package com.patloew.colocation
+
+import com.google.android.gms.tasks.RuntimeExecutionException
+import com.huawei.hmf.tasks.CancellationTokenSource
+import com.huawei.hmf.tasks.Task
+import com.huawei.hmf.tasks.TaskCompletionSource
+import kotlinx.coroutines.*
+import kotlin.coroutines.*
+
+/**
+ * Converts this deferred to the instance of [Task].
+ * If deferred is cancelled then resulting task will be cancelled as well.
+ */
+@ExperimentalCoroutinesApi
+fun <T> Deferred<T>.asTask(): Task<T> {
+    val cancellation = CancellationTokenSource()
+    val source = TaskCompletionSource<T>(cancellation.token)
+
+    invokeOnCompletion callback@{
+        if (it is CancellationException) {
+            cancellation.cancel()
+            return@callback
+        }
+
+        val t = getCompletionExceptionOrNull()
+        if (t == null) {
+            source.setResult(getCompleted())
+        } else {
+            source.setException(t as? Exception ?: RuntimeExecutionException(t))
+        }
+    }
+
+    return source.task
+}
+
+/**
+ * Converts this task to an instance of [Deferred].
+ * If task is cancelled then resulting deferred will be cancelled as well.
+ */
+fun <T> Task<T>.asDeferred(): Deferred<T> {
+    if (isComplete) {
+        val e = exception
+        return if (e == null) {
+            @Suppress("UNCHECKED_CAST")
+            CompletableDeferred<T>().apply { if (isCanceled) cancel() else complete(result as T) }
+        } else {
+            CompletableDeferred<T>().apply { completeExceptionally(e) }
+        }
+    }
+
+    val result = CompletableDeferred<T>()
+    addOnCompleteListener {
+        val e = it.exception
+        if (e == null) {
+            @Suppress("UNCHECKED_CAST")
+            if (isCanceled) result.cancel() else result.complete(it.result as T)
+        } else {
+            result.completeExceptionally(e)
+        }
+    }
+    return result
+}
+
+/**
+ * Awaits for completion of the task without blocking a thread.
+ *
+ * This suspending function is cancellable.
+ * If the [Job] of the current coroutine is cancelled or completed while this suspending function is waiting, this function
+ * stops waiting for the completion stage and immediately resumes with [CancellationException].
+ */
+suspend fun <T> Task<T>.await(): T {
+    // fast path
+    if (isComplete) {
+        val e = exception
+        return if (e == null) {
+            if (isCanceled) {
+                throw CancellationException("Task $this was cancelled normally.")
+            } else {
+                @Suppress("UNCHECKED_CAST")
+                result as T
+            }
+        } else {
+            throw e
+        }
+    }
+
+    return suspendCancellableCoroutine { cont ->
+        addOnCompleteListener {
+            val e = exception
+            if (e == null) {
+                @Suppress("UNCHECKED_CAST")
+                if (isCanceled) cont.cancel() else cont.resume(result as T)
+            } else {
+                cont.resumeWithException(e)
+            }
+        }
+    }
+}

--- a/library/src/test/java/com/patloew/colocation/CoLocationGmsTest.kt
+++ b/library/src/test/java/com/patloew/colocation/CoLocationGmsTest.kt
@@ -1,0 +1,544 @@
+package com.patloew.colocation
+
+import android.content.Context
+import android.location.Location
+import com.google.android.gms.common.api.ResolvableApiException
+import com.google.android.gms.location.*
+import com.google.android.gms.tasks.*
+import com.patloew.colocation.request.LocationRequest
+import io.mockk.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.test.*
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.util.concurrent.TimeUnit
+
+/* Copyright 2020 Patrick Löwenstein
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+@Timeout(5, unit = TimeUnit.SECONDS)
+class CoLocationGmsTest {
+
+    private val locationProvider: FusedLocationProviderClient = mockk()
+    private val settings: SettingsClient = mockk()
+    private val context: Context = mockk()
+    private val testCoroutineDispatcher = TestCoroutineDispatcher()
+    private val testCoroutineScope = TestCoroutineScope()
+
+    private val coLocation = CoLocationGms(context)
+
+    @BeforeEach
+    fun before() {
+        Dispatchers.setMain(testCoroutineDispatcher)
+        mockkStatic(LocationServices::class)
+        every { LocationServices.getFusedLocationProviderClient(context) } returns locationProvider
+        every { LocationServices.getSettingsClient(context) } returns settings
+    }
+
+    @AfterEach
+    fun after() {
+        testCoroutineDispatcher.cleanupTestCoroutines()
+        testCoroutineScope.cleanupTestCoroutines()
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+
+    @Test
+    fun flushLocations() {
+        testTaskWithCancelThrows(
+            createTask = { locationProvider.flushLocations() },
+            taskResult = null,
+            expectedResult = Unit,
+            expectedErrorException = TestException(),
+            coLocationCall = { coLocation.flushLocations() }
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun isLocationAvailable(locationAvailable: Boolean) {
+        val locationAvailability = mockk<LocationAvailability> {
+            every { isLocationAvailable } returns locationAvailable
+        }
+        testTaskWithCancelThrows(
+            createTask = { locationProvider.locationAvailability },
+            taskResult = locationAvailability,
+            expectedResult = locationAvailable,
+            expectedErrorException = TestException(),
+            coLocationCall = { coLocation.isLocationAvailable() }
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        ints = [
+            LocationRequest.PRIORITY_HIGH_ACCURACY,
+            LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY,
+            LocationRequest.PRIORITY_LOW_POWER,
+            LocationRequest.PRIORITY_NO_POWER
+        ]
+    )
+    fun getCurrentLocation(priority: Int) {
+        val location = mockk<Location>()
+        testTaskWithCancelReturns(
+            createTask = { locationProvider.getCurrentLocation(priority, any()) },
+            taskResult = location,
+            expectedResult = location,
+            expectedErrorException = TestException(),
+            cancelResult = null,
+            coLocationCall = { coLocation.getCurrentLocation(priority) }
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        ints = [
+            LocationRequest.PRIORITY_HIGH_ACCURACY,
+            LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY,
+            LocationRequest.PRIORITY_LOW_POWER,
+            LocationRequest.PRIORITY_NO_POWER
+        ]
+    )
+    fun `cancelling getCurrentLocation cancels task`(priority: Int) {
+        val tokenSlot = slot<CancellationToken>()
+
+        every {
+            locationProvider.getCurrentLocation(priority, capture(tokenSlot))
+        } returns mockk(relaxed = true)
+
+        val deferred = testCoroutineScope.async(start = CoroutineStart.UNDISPATCHED) {
+            coLocation.getCurrentLocation(priority)
+        }
+
+        deferred.cancel()
+
+        assertTrue(deferred.isCancelled)
+        assertTrue(tokenSlot.captured.isCancellationRequested)
+    }
+
+    @Test
+    fun getLastLocation() {
+        val location = mockk<Location>()
+        testTaskWithCancelThrows(
+            createTask = { locationProvider.lastLocation },
+            taskResult = location,
+            expectedResult = location,
+            expectedErrorException = TestException(),
+            coLocationCall = { coLocation.getLastLocation() }
+        )
+    }
+
+    @Test
+    fun setMockLocation() {
+        val location: Location = mockk()
+        testTaskWithCancelThrows(
+            createTask = { locationProvider.setMockLocation(location) },
+            taskResult = null,
+            expectedResult = Unit,
+            expectedErrorException = TestException(),
+            coLocationCall = { coLocation.setMockLocation(location) }
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun setMockMode(mockMode: Boolean) {
+        testTaskWithCancelThrows(
+            createTask = { locationProvider.setMockMode(mockMode) },
+            taskResult = null,
+            expectedResult = Unit,
+            expectedErrorException = TestException(),
+            coLocationCall = { coLocation.setMockMode(mockMode) }
+        )
+    }
+
+    @Test
+    fun `getLocationUpdate success`() {
+        val requestTask: Task<Void> = mockk(relaxed = true)
+        val removeTask: Task<Void> = mockk(relaxed = true)
+        val locationRequest: LocationRequest = mockk {
+            every { toGms() } returns mockk {
+                every { numUpdates } returns Integer.MAX_VALUE
+            }
+        }
+        val locations: List<Location> = MutableList(5) { mockk() }
+        val callbackSlot = slot<LocationCallback>()
+        every {
+            locationProvider.requestLocationUpdates(
+                locationRequest.toGms(),
+                capture(callbackSlot),
+                any()
+            )
+        } returns requestTask
+        var result: Location? = null
+
+        val job =
+            testCoroutineScope.launch { result = coLocation.getLocationUpdate(locationRequest) }
+
+        runBlocking {
+            callbackSlot.waitForCapture()
+            every { locationProvider.removeLocationUpdates(callbackSlot.captured) } returns removeTask
+            locations.forEach { location ->
+                callbackSlot.captured.onLocationResult(LocationResult.create(listOf(location)))
+                delay(10)
+            }
+            job.cancelAndJoin()
+        }
+
+        assertEquals(locations[0], result)
+        verify { locationProvider.removeLocationUpdates(callbackSlot.captured) }
+    }
+
+    @Test
+    fun `getLocationUpdate error`() {
+        val requestTask: Task<Void> = mockk(relaxed = true)
+        val testException = TestException()
+        requestTask.mockError(testException)
+        val locationRequest = LocationRequest()
+        every {
+            locationProvider.requestLocationUpdates(
+                locationRequest.toGms(),
+                any(),
+                any()
+            )
+        } returns requestTask
+        var result: Location? = null
+        var resultException: TestException? = null
+
+        testCoroutineScope.runBlockingTest {
+            try {
+                result = coLocation.getLocationUpdate(locationRequest)
+            } catch (e: TestException) {
+                resultException = e
+            }
+        }
+
+        assertNull(result)
+        assertNotNull(resultException)
+    }
+
+    @Test
+    fun `getLocationUpdate cancel`() {
+        val requestTask: Task<Void> = mockk(relaxed = true)
+        requestTask.mockCanceled()
+        val locationRequest = LocationRequest()
+        every {
+            locationProvider.requestLocationUpdates(
+                locationRequest.toGms(),
+                any(),
+                any()
+            )
+        } returns requestTask
+        var result: Location? = null
+        var resultException: TaskCancelledException? = null
+
+        testCoroutineScope.runBlockingTest {
+            try {
+                result = coLocation.getLocationUpdate(locationRequest)
+            } catch (e: TaskCancelledException) {
+                resultException = e
+            }
+        }
+
+        assertNull(result)
+        assertNotNull(resultException)
+    }
+
+    @Test
+    fun `getLocationUpdates success`() {
+        val requestTask: Task<Void> = mockk(relaxed = true)
+        val removeTask: Task<Void> = mockk(relaxed = true)
+        val locationRequest = LocationRequest().setNumUpdates(Integer.MAX_VALUE)
+        val locations: List<Location> = MutableList(5) { mockk() }
+        val callbackSlot = slot<LocationCallback>()
+        every {
+            locationProvider.requestLocationUpdates(
+                locationRequest.toGms(),
+                capture(callbackSlot),
+                any()
+            )
+        } returns requestTask
+
+        val flowResults = mutableListOf<Location>()
+
+        val job = testCoroutineScope.launch {
+            coLocation.getLocationUpdates(locationRequest).collect(flowResults::add)
+        }
+
+        runBlocking {
+            callbackSlot.waitForCapture()
+            every { locationProvider.removeLocationUpdates(callbackSlot.captured) } returns removeTask
+            locations.forEach { location ->
+                callbackSlot.captured.onLocationResult(LocationResult.create(listOf(location)))
+                delay(10)
+            }
+            job.cancelAndJoin()
+        }
+
+        assertEquals(locations, flowResults)
+        verify { locationProvider.removeLocationUpdates(callbackSlot.captured) }
+    }
+
+    @Test
+    fun `getLocationUpdates error`() {
+        val requestTask: Task<Void> = mockk(relaxed = true)
+        val testException = TestException()
+        requestTask.mockError(testException)
+        val locationRequest = LocationRequest()
+        every {
+            locationProvider.requestLocationUpdates(
+                locationRequest.toGms(),
+                any(),
+                any()
+            )
+        } returns requestTask
+        every { locationProvider.removeLocationUpdates(any<LocationCallback>()) } returns mockk()
+        var resultException: CancellationException? = null
+
+        testCoroutineScope.runBlockingTest {
+            try {
+                coLocation.getLocationUpdates(locationRequest).collect()
+            } catch (e: CancellationException) {
+                resultException = e
+            }
+        }
+
+        assertNotNull(resultException)
+        assertEquals(testException, resultException!!.cause!!.cause)
+    }
+
+    @Test
+    fun `getLocationUpdates cancel`() {
+        val requestTask: Task<Void> = mockk(relaxed = true)
+        requestTask.mockCanceled()
+        val locationRequest = LocationRequest()
+        every {
+            locationProvider.requestLocationUpdates(
+                locationRequest.toGms(),
+                any(),
+                any()
+            )
+        } returns requestTask
+        every { locationProvider.removeLocationUpdates(any<LocationCallback>()) } returns mockk()
+        var resultException: CancellationException? = null
+
+        testCoroutineScope.runBlockingTest {
+            try {
+                coLocation.getLocationUpdates(locationRequest).collect()
+            } catch (e: CancellationException) {
+                resultException = e
+            }
+        }
+
+        assertTrue(resultException!!.cause!!.cause is TaskCancelledException)
+    }
+
+    @Test
+    fun `checkLocationSettings satisfied`() {
+        val locationSettingsRequest: com.patloew.colocation.request.LocationSettingsRequest = mockk {
+            every { toGms() } returns mockk()
+        }
+        testTaskSuccess(
+            createTask = { settings.checkLocationSettings(locationSettingsRequest.toGms()) },
+            taskResult = mockk(),
+            expectedResult = CoLocation.SettingsResult.Satisfied,
+            coLocationCall = { coLocation.checkLocationSettings(locationSettingsRequest) }
+        )
+    }
+
+    @Test
+    fun `checkLocationSettings resolvable`() {
+        val locationSettingsRequest: com.patloew.colocation.request.LocationSettingsRequest = mockk {
+            every { toGms() } returns mockk()
+        }
+        val errorTask = mockTask<LocationSettingsResponse>()
+        every { settings.checkLocationSettings(locationSettingsRequest.toGms()) } returns errorTask
+        errorTask.mockError(mockk<ResolvableApiException>())
+        val result = runBlocking { coLocation.checkLocationSettings(locationSettingsRequest) }
+        assertTrue(result is CoLocation.SettingsResult.Resolvable)
+    }
+
+    @Test
+    fun `checkLocationSettings not resolvable`() {
+        val locationSettingsRequest: com.patloew.colocation.request.LocationSettingsRequest = mockk {
+            every { toGms() } returns mockk()
+        }
+        val errorTask = mockTask<LocationSettingsResponse>()
+        every { settings.checkLocationSettings(locationSettingsRequest.toGms()) } returns errorTask
+        errorTask.mockError(TestException())
+        val result = runBlocking { coLocation.checkLocationSettings(locationSettingsRequest) }
+        assertTrue(result is CoLocation.SettingsResult.NotResolvable)
+    }
+
+    @Test
+    fun `checkLocationSettings canceled`() {
+        val locationSettingsRequest: com.patloew.colocation.request.LocationSettingsRequest = mockk {
+            every { toGms() } returns mockk()
+        }
+        assertThrows(TaskCancelledException::class.java) {
+            testTaskCancel(
+                createTask = { settings.checkLocationSettings(locationSettingsRequest.toGms()) },
+                coLocationCall = { coLocation.checkLocationSettings(locationSettingsRequest) }
+            )
+        }
+    }
+
+    @Test
+    fun `checkLocationSettings locationRequest success`() {
+        val locationRequest = LocationRequest()
+        testTaskSuccess(
+            createTask = { settings.checkLocationSettings(any()) },
+            taskResult = mockk(),
+            expectedResult = CoLocation.SettingsResult.Satisfied,
+            coLocationCall = { coLocation.checkLocationSettings(locationRequest) }
+        )
+    }
+
+    private fun <T, R> testTaskWithCancelThrows(
+        createTask: MockKMatcherScope.() -> Task<T>,
+        taskResult: T,
+        expectedResult: R,
+        expectedErrorException: Exception,
+        coLocationCall: suspend CoroutineScope.() -> R
+    ) {
+        testTaskSuccess(createTask, taskResult, expectedResult, coLocationCall)
+        testTaskFailure(createTask, expectedErrorException, coLocationCall)
+        assertThrows(CancellationException::class.java) {
+            testTaskCancel(
+                createTask,
+                coLocationCall
+            )
+        }
+    }
+
+    private fun <T, R> testTaskWithCancelReturns(
+        createTask: MockKMatcherScope.() -> Task<T>,
+        taskResult: T,
+        expectedResult: R?,
+        expectedErrorException: Exception,
+        cancelResult: R?,
+        coLocationCall: suspend CoroutineScope.() -> R
+    ) {
+        testTaskSuccess(createTask, taskResult, expectedResult, coLocationCall)
+        testTaskFailure(createTask, expectedErrorException, coLocationCall)
+        assertEquals(cancelResult, testTaskCancel(createTask, coLocationCall))
+    }
+
+    private fun <T, R> testTaskCancel(
+        createTask: MockKMatcherScope.() -> Task<T>,
+        coLocationCall: suspend CoroutineScope.() -> R
+    ): R? {
+        val cancelTask = mockTask<T>()
+        every { createTask() } returns cancelTask
+
+        cancelTask.mockCanceled()
+
+        return runBlocking { coLocationCall() }
+    }
+
+    private fun <T, R> testTaskSuccess(
+        createTask: MockKMatcherScope.() -> Task<T>,
+        taskResult: T,
+        expectedResult: R,
+        coLocationCall: suspend CoroutineScope.() -> R
+    ) {
+        val successTask = mockTask<T>()
+        every { createTask() } returns successTask
+
+        successTask.mockSuccess(taskResult)
+
+        assertEquals(expectedResult, runBlocking { coLocationCall() })
+    }
+
+    private fun <T, R> testTaskFailure(
+        createTask: MockKMatcherScope.() -> Task<T>,
+        expectedErrorException: Exception,
+        coLocationCall: suspend CoroutineScope.() -> R
+    ) {
+        val errorTask = mockTask<T>()
+        every { createTask() } returns errorTask
+
+        assertThrows(expectedErrorException::class.java) {
+            errorTask.mockError(expectedErrorException)
+            runBlocking { coLocationCall() }
+        }
+
+    }
+
+
+    private fun <T> Task<T>.mockSuccess(taskResult: T) {
+        every { isComplete } returns false
+        every { isCanceled } returns false
+        every { exception } returns null
+        every { result } returns taskResult
+        every { addOnCompleteListener(any()) } answers {
+            val task = self as Task<T>
+            firstArg<OnCompleteListener<T>>().onComplete(task)
+            task
+        }
+        every { addOnSuccessListener(any()) } answers {
+            firstArg<OnSuccessListener<T>>().onSuccess(taskResult)
+            self as Task<T>
+        }
+    }
+
+
+    private fun <E : Exception, T> Task<T>.mockError(e: E) {
+        every { isComplete } returns false
+        every { exception } returns e
+        every { addOnCompleteListener(any()) } answers {
+            val task = self as Task<T>
+            firstArg<OnCompleteListener<T>>().onComplete(task)
+            task
+        }
+        every { addOnFailureListener(any()) } answers {
+            firstArg<OnFailureListener>().onFailure(e)
+            self as Task<T>
+        }
+    }
+
+    private fun <T> Task<T>.mockCanceled() {
+        every { isComplete } returns false
+        every { isCanceled } returns true
+        every { exception } returns null
+        every { addOnCompleteListener(any()) } answers {
+            val task = self as Task<T>
+            firstArg<OnCompleteListener<T>>().onComplete(task)
+            task
+        }
+        every { addOnCanceledListener(any()) } answers {
+            firstArg<OnCanceledListener>().onCanceled()
+            self as Task<T>
+        }
+    }
+
+    private fun <T> mockTask() = mockk<Task<T>>().apply {
+        every { addOnSuccessListener(any()) } returns this
+        every { addOnCanceledListener(any()) } returns this
+        every { addOnFailureListener(any()) } returns this
+    }
+
+    private suspend fun CapturingSlot<*>.waitForCapture() {
+        while (!isCaptured) {
+            delay(1)
+        }
+    }
+
+    class TestException : Exception()
+}

--- a/library/src/test/java/com/patloew/colocation/CoLocationHmsTest.kt
+++ b/library/src/test/java/com/patloew/colocation/CoLocationHmsTest.kt
@@ -1,0 +1,557 @@
+package com.patloew.colocation
+
+import android.content.Context
+import android.location.Location
+import com.huawei.hmf.tasks.OnCanceledListener
+import com.huawei.hmf.tasks.OnCompleteListener
+import com.huawei.hmf.tasks.OnFailureListener
+import com.huawei.hmf.tasks.OnSuccessListener
+import com.huawei.hmf.tasks.Task
+import com.huawei.hms.common.ResolvableApiException
+import com.huawei.hms.location.FusedLocationProviderClient
+import com.huawei.hms.location.LocationAvailability
+import com.huawei.hms.location.LocationCallback
+import com.huawei.hms.location.LocationServices
+import com.huawei.hms.location.LocationSettingsResponse
+import com.huawei.hms.location.SettingsClient
+import com.patloew.colocation.request.LocationRequest
+import io.mockk.CapturingSlot
+import io.mockk.MockKMatcherScope
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.util.concurrent.TimeUnit
+
+/* Copyright 2020 Patrick Löwenstein
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+@Timeout(5, unit = TimeUnit.SECONDS)
+class CoLocationHmsTest {
+
+    private val locationProvider: FusedLocationProviderClient = mockk()
+    private val settings: SettingsClient = mockk()
+    private val context: Context = mockk()
+    private val testCoroutineDispatcher = TestCoroutineDispatcher()
+    private val testCoroutineScope = TestCoroutineScope()
+
+    private val coLocation = CoLocationHms(context)
+
+    @BeforeEach
+    fun before() {
+        Dispatchers.setMain(testCoroutineDispatcher)
+        mockkStatic(LocationServices::class)
+        every { LocationServices.getFusedLocationProviderClient(context) } returns locationProvider
+        every { LocationServices.getSettingsClient(context) } returns settings
+    }
+
+    @AfterEach
+    fun after() {
+        testCoroutineDispatcher.cleanupTestCoroutines()
+        testCoroutineScope.cleanupTestCoroutines()
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+
+    @Test
+    fun flushLocations() {
+        testTaskWithCancelThrows(
+            createTask = { locationProvider.flushLocations() },
+            taskResult = null,
+            expectedResult = Unit,
+            expectedErrorException = TestException(),
+            coLocationCall = { coLocation.flushLocations() }
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun isLocationAvailable(locationAvailable: Boolean) {
+        val locationAvailability = mockk<LocationAvailability> {
+            every { isLocationAvailable } returns locationAvailable
+        }
+        testTaskWithCancelThrows(
+            createTask = { locationProvider.locationAvailability },
+            taskResult = locationAvailability,
+            expectedResult = locationAvailable,
+            expectedErrorException = TestException(),
+            coLocationCall = { coLocation.isLocationAvailable() }
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        ints = [
+            LocationRequest.PRIORITY_HIGH_ACCURACY,
+            LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY,
+            LocationRequest.PRIORITY_LOW_POWER,
+            LocationRequest.PRIORITY_NO_POWER
+        ]
+    )
+    fun getCurrentLocation(priority: Int) {
+        var result: Location? = null
+
+        testCoroutineScope.runBlockingTest {
+            result = coLocation.getCurrentLocation(priority)
+        }
+        assertNull(result)
+    }
+
+    @Test
+    fun getLastLocation() {
+        val location = mockk<Location>()
+        testTaskWithCancelThrows(
+            createTask = { locationProvider.lastLocation },
+            taskResult = location,
+            expectedResult = location,
+            expectedErrorException = TestException(),
+            coLocationCall = { coLocation.getLastLocation() }
+        )
+    }
+
+    @Test
+    fun setMockLocation() {
+        val location: Location = mockk()
+        testTaskWithCancelThrows(
+            createTask = { locationProvider.setMockLocation(location) },
+            taskResult = null,
+            expectedResult = Unit,
+            expectedErrorException = TestException(),
+            coLocationCall = { coLocation.setMockLocation(location) }
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun setMockMode(mockMode: Boolean) {
+        testTaskWithCancelThrows(
+            createTask = { locationProvider.setMockMode(mockMode) },
+            taskResult = null,
+            expectedResult = Unit,
+            expectedErrorException = TestException(),
+            coLocationCall = { coLocation.setMockMode(mockMode) }
+        )
+    }
+
+    @Test
+    fun `getLocationUpdate success`() {
+        val requestTask: Task<Void> = mockk(relaxed = true)
+        val removeTask: Task<Void> = mockk(relaxed = true)
+        val locationRequest: LocationRequest = mockk {
+            every { toGms() } returns mockk {
+                every { numUpdates } returns Integer.MAX_VALUE
+            }
+        }
+        val locations: List<Location> = MutableList(5) { mockk() }
+        val callbackSlot = slot<LocationCallback>()
+        every {
+            locationProvider.requestLocationUpdates(
+                locationRequest.toHms(),
+                capture(callbackSlot),
+                any()
+            )
+        } returns requestTask
+        var result: Location? = null
+
+        val job =
+            testCoroutineScope.launch { result = coLocation.getLocationUpdate(locationRequest) }
+
+        runBlocking {
+            callbackSlot.waitForCapture()
+            every { locationProvider.removeLocationUpdates(callbackSlot.captured) } returns removeTask
+            locations.forEach { location ->
+                callbackSlot.captured.onLocationResult(
+                    mockk {
+                        every { lastLocation } returns location
+                    }
+                )
+                delay(10)
+            }
+            job.cancelAndJoin()
+        }
+
+        assertEquals(locations[0], result)
+        verify { locationProvider.removeLocationUpdates(callbackSlot.captured) }
+    }
+
+    @Test
+    fun `getLocationUpdate error`() {
+        val requestTask: Task<Void> = mockk(relaxed = true)
+        val testException = TestException()
+        requestTask.mockError(testException)
+        val locationRequest = LocationRequest()
+        every {
+            locationProvider.requestLocationUpdates(
+                locationRequest.toHms(),
+                any(),
+                any()
+            )
+        } returns requestTask
+        var result: Location? = null
+        var resultException: TestException? = null
+
+        testCoroutineScope.runBlockingTest {
+            try {
+                result = coLocation.getLocationUpdate(locationRequest)
+            } catch (e: TestException) {
+                resultException = e
+            }
+        }
+
+        assertNull(result)
+        assertNotNull(resultException)
+    }
+
+    @Test
+    fun `getLocationUpdate cancel`() {
+        val requestTask: Task<Void> = mockk(relaxed = true)
+        requestTask.mockCanceled()
+        val locationRequest = LocationRequest()
+        every {
+            locationProvider.requestLocationUpdates(
+                locationRequest.toHms(),
+                any(),
+                any()
+            )
+        } returns requestTask
+        var result: Location? = null
+        var resultException: TaskCancelledException? = null
+
+        testCoroutineScope.runBlockingTest {
+            try {
+                result = coLocation.getLocationUpdate(locationRequest)
+            } catch (e: TaskCancelledException) {
+                resultException = e
+            }
+        }
+
+        assertNull(result)
+        assertNotNull(resultException)
+    }
+
+    @Test
+    fun `getLocationUpdates success`() {
+        val requestTask: Task<Void> = mockk(relaxed = true)
+        val removeTask: Task<Void> = mockk(relaxed = true)
+        val locationRequest = LocationRequest().setNumUpdates(Integer.MAX_VALUE)
+        val locations: List<Location> = MutableList(5) { mockk() }
+        val callbackSlot = slot<LocationCallback>()
+        every {
+            locationProvider.requestLocationUpdates(
+                locationRequest.toHms(),
+                capture(callbackSlot),
+                any()
+            )
+        } returns requestTask
+
+        val flowResults = mutableListOf<Location>()
+
+        val job = testCoroutineScope.launch {
+            coLocation.getLocationUpdates(locationRequest).collect(flowResults::add)
+        }
+
+        runBlocking {
+            callbackSlot.waitForCapture()
+            every { locationProvider.removeLocationUpdates(callbackSlot.captured) } returns removeTask
+            locations.forEach { location ->
+                callbackSlot.captured.onLocationResult(
+                    mockk {
+                        every { lastLocation } returns location
+                    }
+                )
+                delay(10)
+            }
+            job.cancelAndJoin()
+        }
+
+        assertEquals(locations, flowResults)
+        verify { locationProvider.removeLocationUpdates(callbackSlot.captured) }
+    }
+
+    @Test
+    fun `getLocationUpdates error`() {
+        val requestTask: Task<Void> = mockk(relaxed = true)
+        val testException = TestException()
+        requestTask.mockError(testException)
+        val locationRequest = LocationRequest()
+        every {
+            locationProvider.requestLocationUpdates(
+                locationRequest.toHms(),
+                any(),
+                any()
+            )
+        } returns requestTask
+        every { locationProvider.removeLocationUpdates(any<LocationCallback>()) } returns mockk()
+        var resultException: CancellationException? = null
+
+        testCoroutineScope.runBlockingTest {
+            try {
+                coLocation.getLocationUpdates(locationRequest).collect()
+            } catch (e: CancellationException) {
+                resultException = e
+            }
+        }
+
+        assertNotNull(resultException)
+        assertEquals(testException, resultException!!.cause!!.cause)
+    }
+
+    @Test
+    fun `getLocationUpdates cancel`() {
+        val requestTask: Task<Void> = mockk(relaxed = true)
+        requestTask.mockCanceled()
+        val locationRequest = LocationRequest()
+        every {
+            locationProvider.requestLocationUpdates(
+                locationRequest.toHms(),
+                any(),
+                any()
+            )
+        } returns requestTask
+        every { locationProvider.removeLocationUpdates(any<LocationCallback>()) } returns mockk()
+        var resultException: CancellationException? = null
+
+        testCoroutineScope.runBlockingTest {
+            try {
+                coLocation.getLocationUpdates(locationRequest).collect()
+            } catch (e: CancellationException) {
+                resultException = e
+            }
+        }
+
+        assertTrue(resultException!!.cause!!.cause is TaskCancelledException)
+    }
+
+    @Test
+    fun `checkLocationSettings satisfied`() {
+        val locationSettingsRequest: com.patloew.colocation.request.LocationSettingsRequest =
+            mockk {
+                every { toGms() } returns mockk()
+            }
+        testTaskSuccess(
+            createTask = { settings.checkLocationSettings(locationSettingsRequest.toHms()) },
+            taskResult = mockk(),
+            expectedResult = CoLocation.SettingsResult.Satisfied,
+            coLocationCall = { coLocation.checkLocationSettings(locationSettingsRequest) }
+        )
+    }
+
+    @Test
+    fun `checkLocationSettings resolvable`() {
+        val locationSettingsRequest: com.patloew.colocation.request.LocationSettingsRequest =
+            mockk {
+                every { toGms() } returns mockk()
+            }
+        val errorTask = mockTask<LocationSettingsResponse>()
+        every { settings.checkLocationSettings(locationSettingsRequest.toHms()) } returns errorTask
+        errorTask.mockError(mockk<ResolvableApiException>())
+        val result = runBlocking { coLocation.checkLocationSettings(locationSettingsRequest) }
+        assertTrue(result is CoLocation.SettingsResult.Resolvable)
+    }
+
+    @Test
+    fun `checkLocationSettings not resolvable`() {
+        val locationSettingsRequest: com.patloew.colocation.request.LocationSettingsRequest =
+            mockk {
+                every { toGms() } returns mockk()
+            }
+        val errorTask = mockTask<LocationSettingsResponse>()
+        every { settings.checkLocationSettings(locationSettingsRequest.toHms()) } returns errorTask
+        errorTask.mockError(TestException())
+        val result = runBlocking { coLocation.checkLocationSettings(locationSettingsRequest) }
+        assertTrue(result is CoLocation.SettingsResult.NotResolvable)
+    }
+
+    @Test
+    fun `checkLocationSettings canceled`() {
+        val locationSettingsRequest: com.patloew.colocation.request.LocationSettingsRequest =
+            mockk {
+                every { toGms() } returns mockk()
+            }
+        assertThrows(TaskCancelledException::class.java) {
+            testTaskCancel(
+                createTask = { settings.checkLocationSettings(locationSettingsRequest.toHms()) },
+                coLocationCall = { coLocation.checkLocationSettings(locationSettingsRequest) }
+            )
+        }
+    }
+
+    @Test
+    fun `checkLocationSettings locationRequest success`() {
+        val locationRequest = LocationRequest()
+        testTaskSuccess(
+            createTask = { settings.checkLocationSettings(any()) },
+            taskResult = mockk(),
+            expectedResult = CoLocation.SettingsResult.Satisfied,
+            coLocationCall = { coLocation.checkLocationSettings(locationRequest) }
+        )
+    }
+
+    private fun <T, R> testTaskWithCancelThrows(
+        createTask: MockKMatcherScope.() -> Task<T>,
+        taskResult: T,
+        expectedResult: R,
+        expectedErrorException: Exception,
+        coLocationCall: suspend CoroutineScope.() -> R
+    ) {
+        testTaskSuccess(createTask, taskResult, expectedResult, coLocationCall)
+        testTaskFailure(createTask, expectedErrorException, coLocationCall)
+        assertThrows(CancellationException::class.java) {
+            testTaskCancel(
+                createTask,
+                coLocationCall
+            )
+        }
+    }
+
+    private fun <T, R> testTaskWithCancelReturns(
+        createTask: MockKMatcherScope.() -> Task<T>,
+        taskResult: T,
+        expectedResult: R?,
+        expectedErrorException: Exception,
+        cancelResult: R?,
+        coLocationCall: suspend CoroutineScope.() -> R
+    ) {
+        testTaskSuccess(createTask, taskResult, expectedResult, coLocationCall)
+        testTaskFailure(createTask, expectedErrorException, coLocationCall)
+        assertEquals(cancelResult, testTaskCancel(createTask, coLocationCall))
+    }
+
+    private fun <T, R> testTaskCancel(
+        createTask: MockKMatcherScope.() -> Task<T>,
+        coLocationCall: suspend CoroutineScope.() -> R
+    ): R? {
+        val cancelTask = mockTask<T>()
+        every { createTask() } returns cancelTask
+
+        cancelTask.mockCanceled()
+
+        return runBlocking { coLocationCall() }
+    }
+
+    private fun <T, R> testTaskSuccess(
+        createTask: MockKMatcherScope.() -> Task<T>,
+        taskResult: T,
+        expectedResult: R,
+        coLocationCall: suspend CoroutineScope.() -> R
+    ) {
+        val successTask = mockTask<T>()
+        every { createTask() } returns successTask
+
+        successTask.mockSuccess(taskResult)
+
+        assertEquals(expectedResult, runBlocking { coLocationCall() })
+    }
+
+    private fun <T, R> testTaskFailure(
+        createTask: MockKMatcherScope.() -> Task<T>,
+        expectedErrorException: Exception,
+        coLocationCall: suspend CoroutineScope.() -> R
+    ) {
+        val errorTask = mockTask<T>()
+        every { createTask() } returns errorTask
+
+        assertThrows(expectedErrorException::class.java) {
+            errorTask.mockError(expectedErrorException)
+            runBlocking { coLocationCall() }
+        }
+
+    }
+
+
+    private fun <T> Task<T>.mockSuccess(taskResult: T) {
+        every { isComplete } returns false
+        every { isCanceled } returns false
+        every { exception } returns null
+        every { result } returns taskResult
+        every { addOnCompleteListener(any()) } answers {
+            val task = self as Task<T>
+            firstArg<OnCompleteListener<T>>().onComplete(task)
+            task
+        }
+        every { addOnSuccessListener(any()) } answers {
+            firstArg<OnSuccessListener<T>>().onSuccess(taskResult)
+            self as Task<T>
+        }
+    }
+
+
+    private fun <E : Exception, T> Task<T>.mockError(e: E) {
+        every { isComplete } returns false
+        every { exception } returns e
+        every { addOnCompleteListener(any()) } answers {
+            val task = self as Task<T>
+            firstArg<OnCompleteListener<T>>().onComplete(task)
+            task
+        }
+        every { addOnFailureListener(any()) } answers {
+            firstArg<OnFailureListener>().onFailure(e)
+            self as Task<T>
+        }
+    }
+
+    private fun <T> Task<T>.mockCanceled() {
+        every { isComplete } returns false
+        every { isCanceled } returns true
+        every { exception } returns null
+        every { addOnCompleteListener(any()) } answers {
+            val task = self as Task<T>
+            firstArg<OnCompleteListener<T>>().onComplete(task)
+            task
+        }
+        every { addOnCanceledListener(any()) } answers {
+            firstArg<OnCanceledListener>().onCanceled()
+            self as Task<T>
+        }
+    }
+
+    private fun <T> mockTask() = mockk<Task<T>>().apply {
+        every { addOnSuccessListener(any()) } returns this
+        every { addOnCanceledListener(any()) } returns this
+        every { addOnFailureListener(any()) } returns this
+    }
+
+    private suspend fun CapturingSlot<*>.waitForCapture() {
+        while (!isCaptured) {
+            delay(1)
+        }
+    }
+
+    class TestException : Exception()
+}

--- a/library/src/test/java/com/patloew/colocation/CoLocationTest.kt
+++ b/library/src/test/java/com/patloew/colocation/CoLocationTest.kt
@@ -1,503 +1,53 @@
 package com.patloew.colocation
 
 import android.content.Context
-import android.location.Location
-import com.google.android.gms.common.api.ResolvableApiException
-import com.google.android.gms.location.*
-import com.google.android.gms.tasks.*
-import io.mockk.*
-import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.test.*
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.BeforeEach
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
+import org.junit.jupiter.api.assertThrows
 import java.util.concurrent.TimeUnit
+import kotlin.IllegalStateException
 
-/* Copyright 2020 Patrick Löwenstein
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License. */
 @Timeout(5, unit = TimeUnit.SECONDS)
 class CoLocationTest {
 
-    private val locationProvider: FusedLocationProviderClient = mockk()
-    private val settings: SettingsClient = mockk()
     private val context: Context = mockk()
-    private val testCoroutineDispatcher = TestCoroutineDispatcher()
-    private val testCoroutineScope = TestCoroutineScope()
 
-    private val coLocation = CoLocationImpl(context)
+    private val gmsSource = LocationServicesSource.GMS
+    private val hmsSource = LocationServicesSource.HMS
+    private val noneSource = LocationServicesSource.NONE
 
-    @BeforeEach
-    fun before() {
-        Dispatchers.setMain(testCoroutineDispatcher)
-        mockkStatic(LocationServices::class)
-        every { LocationServices.getFusedLocationProviderClient(context) } returns locationProvider
-        every { LocationServices.getSettingsClient(context) } returns settings
-    }
+    @Test
+    fun testCorrectSourceIsUsed() {
+        val gmsCoLocation = CoLocation.from(context, gmsSource)
+        val hmsCoLocation = CoLocation.from(context, hmsSource)
 
-    @AfterEach
-    fun after() {
-        testCoroutineDispatcher.cleanupTestCoroutines()
-        testCoroutineScope.cleanupTestCoroutines()
-        Dispatchers.resetMain()
-        unmockkAll()
+        assert(gmsCoLocation is CoLocationGms)
+        assert(hmsCoLocation is CoLocationHms)
     }
 
     @Test
-    fun flushLocations() {
-        testTaskWithCancelThrows(
-            createTask = { locationProvider.flushLocations() },
-            taskResult = null,
-            expectedResult = Unit,
-            expectedErrorException = TestException(),
-            coLocationCall = { coLocation.flushLocations() }
-        )
-    }
-
-    @ParameterizedTest
-    @ValueSource(booleans = [false, true])
-    fun isLocationAvailable(locationAvailable: Boolean) {
-        val locationAvailability = mockk<LocationAvailability> {
-            every { isLocationAvailable } returns locationAvailable
-        }
-        testTaskWithCancelThrows(
-            createTask = { locationProvider.locationAvailability },
-            taskResult = locationAvailability,
-            expectedResult = locationAvailable,
-            expectedErrorException = TestException(),
-            coLocationCall = { coLocation.isLocationAvailable() }
-        )
-    }
-
-    @ParameterizedTest
-    @ValueSource(
-        ints = [
-            LocationRequest.PRIORITY_HIGH_ACCURACY,
-            LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY,
-            LocationRequest.PRIORITY_LOW_POWER,
-            LocationRequest.PRIORITY_NO_POWER
-        ]
-    )
-    fun getCurrentLocation(priority: Int) {
-        val location = mockk<Location>()
-        testTaskWithCancelReturns(
-            createTask = { locationProvider.getCurrentLocation(priority, any()) },
-            taskResult = location,
-            expectedResult = location,
-            expectedErrorException = TestException(),
-            cancelResult = null,
-            coLocationCall = { coLocation.getCurrentLocation(priority) }
-        )
-    }
-
-    @ParameterizedTest
-    @ValueSource(
-        ints = [
-            LocationRequest.PRIORITY_HIGH_ACCURACY,
-            LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY,
-            LocationRequest.PRIORITY_LOW_POWER,
-            LocationRequest.PRIORITY_NO_POWER
-        ]
-    )
-    fun `cancelling getCurrentLocation cancels task`(priority: Int) {
-        val tokenSlot = slot<CancellationToken>()
+    fun testCorrectSourceIsFound() {
+        mockkStatic(context::getLocationServiceSource)
 
         every {
-            locationProvider.getCurrentLocation(priority, capture(tokenSlot))
-        } returns mockk(relaxed = true)
+            context.getLocationServiceSource()
+        } returns gmsSource
+        val gmsCoLocation = CoLocation.from(context)
 
-        val deferred = testCoroutineScope.async(start = CoroutineStart.UNDISPATCHED) {
-            coLocation.getCurrentLocation(priority)
-        }
-
-        deferred.cancel()
-
-        assertTrue(deferred.isCancelled)
-        assertTrue(tokenSlot.captured.isCancellationRequested)
-    }
-
-    @Test
-    fun getLastLocation() {
-        val location = mockk<Location>()
-        testTaskWithCancelThrows(
-            createTask = { locationProvider.lastLocation },
-            taskResult = location,
-            expectedResult = location,
-            expectedErrorException = TestException(),
-            coLocationCall = { coLocation.getLastLocation() }
-        )
-    }
-
-    @Test
-    fun setMockLocation() {
-        val location: Location = mockk()
-        testTaskWithCancelThrows(
-            createTask = { locationProvider.setMockLocation(location) },
-            taskResult = null,
-            expectedResult = Unit,
-            expectedErrorException = TestException(),
-            coLocationCall = { coLocation.setMockLocation(location) }
-        )
-    }
-
-    @ParameterizedTest
-    @ValueSource(booleans = [false, true])
-    fun setMockMode(mockMode: Boolean) {
-        testTaskWithCancelThrows(
-            createTask = { locationProvider.setMockMode(mockMode) },
-            taskResult = null,
-            expectedResult = Unit,
-            expectedErrorException = TestException(),
-            coLocationCall = { coLocation.setMockMode(mockMode) }
-        )
-    }
-
-    @Test
-    fun `getLocationUpdate success`() {
-        val requestTask: Task<Void> = mockk(relaxed = true)
-        val removeTask: Task<Void> = mockk(relaxed = true)
-        val locationRequest: LocationRequest = mockk {
-            every { numUpdates } returns Integer.MAX_VALUE
-        }
-        val locations: List<Location> = MutableList(5) { mockk() }
-        val callbackSlot = slot<LocationCallback>()
         every {
-            locationProvider.requestLocationUpdates(
-                locationRequest,
-                capture(callbackSlot),
-                any()
-            )
-        } returns requestTask
-        var result: Location? = null
+            context.getLocationServiceSource()
+        } returns hmsSource
+        val hmsCoLocation = CoLocation.from(context)
 
-        val job = testCoroutineScope.launch { result = coLocation.getLocationUpdate(locationRequest) }
-
-        runBlocking {
-            callbackSlot.waitForCapture()
-            every { locationProvider.removeLocationUpdates(callbackSlot.captured) } returns removeTask
-            locations.forEach { location ->
-                callbackSlot.captured.onLocationResult(LocationResult.create(listOf(location)))
-                delay(10)
-            }
-            job.cancelAndJoin()
-        }
-
-        assertEquals(locations[0], result)
-        verify { locationProvider.removeLocationUpdates(callbackSlot.captured) }
+        assert(gmsCoLocation is CoLocationGms)
+        assert(hmsCoLocation is CoLocationHms)
     }
 
     @Test
-    fun `getLocationUpdate error`() {
-        val requestTask: Task<Void> = mockk(relaxed = true)
-        val testException = TestException()
-        requestTask.mockError(testException)
-        val locationRequest: LocationRequest = mockk()
-        every { locationProvider.requestLocationUpdates(locationRequest, any(), any()) } returns requestTask
-        var result: Location? = null
-        var resultException: TestException? = null
-
-        testCoroutineScope.runBlockingTest {
-            try {
-                result = coLocation.getLocationUpdate(locationRequest)
-            } catch (e: TestException) {
-                resultException = e
-            }
-        }
-
-        assertNull(result)
-        assertNotNull(resultException)
+    fun throwsOnIncorrectSource() {
+        assertThrows<IllegalStateException> { CoLocation.from(context, noneSource) }
     }
-
-    @Test
-    fun `getLocationUpdate cancel`() {
-        val requestTask: Task<Void> = mockk(relaxed = true)
-        requestTask.mockCanceled()
-        val locationRequest: LocationRequest = mockk()
-        every { locationProvider.requestLocationUpdates(locationRequest, any(), any()) } returns requestTask
-        var result: Location? = null
-        var resultException: TaskCancelledException? = null
-
-        testCoroutineScope.runBlockingTest {
-            try {
-                result = coLocation.getLocationUpdate(locationRequest)
-            } catch (e: TaskCancelledException) {
-                resultException = e
-            }
-        }
-
-        assertNull(result)
-        assertNotNull(resultException)
-    }
-
-    @Test
-    fun `getLocationUpdates success`() {
-        val requestTask: Task<Void> = mockk(relaxed = true)
-        val removeTask: Task<Void> = mockk(relaxed = true)
-        val locationRequest: LocationRequest = mockk {
-            every { numUpdates } returns Integer.MAX_VALUE
-        }
-        val locations: List<Location> = MutableList(5) { mockk() }
-        val callbackSlot = slot<LocationCallback>()
-        every {
-            locationProvider.requestLocationUpdates(
-                locationRequest,
-                capture(callbackSlot),
-                any()
-            )
-        } returns requestTask
-
-        val flowResults = mutableListOf<Location>()
-
-        val job = testCoroutineScope.launch { coLocation.getLocationUpdates(locationRequest).collect(flowResults::add) }
-
-        runBlocking {
-            callbackSlot.waitForCapture()
-            every { locationProvider.removeLocationUpdates(callbackSlot.captured) } returns removeTask
-            locations.forEach { location ->
-                callbackSlot.captured.onLocationResult(LocationResult.create(listOf(location)))
-                delay(10)
-            }
-            job.cancelAndJoin()
-        }
-
-        assertEquals(locations, flowResults)
-        verify { locationProvider.removeLocationUpdates(callbackSlot.captured) }
-    }
-
-    @Test
-    fun `getLocationUpdates error`() {
-        val requestTask: Task<Void> = mockk(relaxed = true)
-        val testException = TestException()
-        requestTask.mockError(testException)
-        val locationRequest: LocationRequest = mockk()
-        every { locationProvider.requestLocationUpdates(locationRequest, any(), any()) } returns requestTask
-        every { locationProvider.removeLocationUpdates(any<LocationCallback>()) } returns mockk()
-        var resultException: CancellationException? = null
-
-        testCoroutineScope.runBlockingTest {
-            try {
-                coLocation.getLocationUpdates(locationRequest).collect()
-            } catch (e: CancellationException) {
-                resultException = e
-            }
-        }
-
-        assertNotNull(resultException)
-        assertEquals(testException, resultException!!.cause!!.cause)
-    }
-
-    @Test
-    fun `getLocationUpdates cancel`() {
-        val requestTask: Task<Void> = mockk(relaxed = true)
-        requestTask.mockCanceled()
-        val locationRequest: LocationRequest = mockk()
-        every { locationProvider.requestLocationUpdates(locationRequest, any(), any()) } returns requestTask
-        every { locationProvider.removeLocationUpdates(any<LocationCallback>()) } returns mockk()
-        var resultException: CancellationException? = null
-
-        testCoroutineScope.runBlockingTest {
-            try {
-                coLocation.getLocationUpdates(locationRequest).collect()
-            } catch (e: CancellationException) {
-                resultException = e
-            }
-        }
-
-        assertTrue(resultException!!.cause!!.cause is TaskCancelledException)
-    }
-
-    @Test
-    fun `checkLocationSettings satisfied`() {
-        val locationSettingsRequest: LocationSettingsRequest = mockk()
-        testTaskSuccess(
-            createTask = { settings.checkLocationSettings(locationSettingsRequest) },
-            taskResult = mockk(),
-            expectedResult = CoLocation.SettingsResult.Satisfied,
-            coLocationCall = { coLocation.checkLocationSettings(locationSettingsRequest) }
-        )
-    }
-
-    @Test
-    fun `checkLocationSettings resolvable`() {
-        val locationSettingsRequest: LocationSettingsRequest = mockk()
-        val errorTask = mockTask<LocationSettingsResponse>()
-        every { settings.checkLocationSettings(locationSettingsRequest) } returns errorTask
-        errorTask.mockError(mockk<ResolvableApiException>())
-        val result = runBlocking { coLocation.checkLocationSettings(locationSettingsRequest) }
-        assertTrue(result is CoLocation.SettingsResult.Resolvable)
-    }
-
-    @Test
-    fun `checkLocationSettings not resolvable`() {
-        val locationSettingsRequest: LocationSettingsRequest = mockk()
-        val errorTask = mockTask<LocationSettingsResponse>()
-        every { settings.checkLocationSettings(locationSettingsRequest) } returns errorTask
-        errorTask.mockError(TestException())
-        val result = runBlocking { coLocation.checkLocationSettings(locationSettingsRequest) }
-        assertTrue(result is CoLocation.SettingsResult.NotResolvable)
-    }
-
-    @Test
-    fun `checkLocationSettings canceled`() {
-        val locationSettingsRequest: LocationSettingsRequest = mockk()
-        assertThrows(TaskCancelledException::class.java) {
-            testTaskCancel(
-                createTask = { settings.checkLocationSettings(locationSettingsRequest) },
-                coLocationCall = { coLocation.checkLocationSettings(locationSettingsRequest) }
-            )
-        }
-    }
-
-    @Test
-    fun `checkLocationSettings locationRequest success`() {
-        val locationRequest: LocationRequest = mockk()
-        testTaskSuccess(
-            createTask = { settings.checkLocationSettings(any()) },
-            taskResult = mockk(),
-            expectedResult = CoLocation.SettingsResult.Satisfied,
-            coLocationCall = { coLocation.checkLocationSettings(locationRequest) }
-        )
-    }
-
-    private fun <T, R> testTaskWithCancelThrows(
-        createTask: MockKMatcherScope.() -> Task<T>,
-        taskResult: T,
-        expectedResult: R,
-        expectedErrorException: Exception,
-        coLocationCall: suspend CoroutineScope.() -> R
-    ) {
-        testTaskSuccess(createTask, taskResult, expectedResult, coLocationCall)
-        testTaskFailure(createTask, expectedErrorException, coLocationCall)
-        assertThrows(CancellationException::class.java) { testTaskCancel(createTask, coLocationCall) }
-    }
-
-    private fun <T, R> testTaskWithCancelReturns(
-        createTask: MockKMatcherScope.() -> Task<T>,
-        taskResult: T,
-        expectedResult: R?,
-        expectedErrorException: Exception,
-        cancelResult: R?,
-        coLocationCall: suspend CoroutineScope.() -> R
-    ) {
-        testTaskSuccess(createTask, taskResult, expectedResult, coLocationCall)
-        testTaskFailure(createTask, expectedErrorException, coLocationCall)
-        assertEquals(cancelResult, testTaskCancel(createTask, coLocationCall))
-    }
-
-    private fun <T, R> testTaskCancel(
-        createTask: MockKMatcherScope.() -> Task<T>,
-        coLocationCall: suspend CoroutineScope.() -> R
-    ): R? {
-        val cancelTask = mockTask<T>()
-        every { createTask() } returns cancelTask
-
-        cancelTask.mockCanceled()
-
-        return runBlocking { coLocationCall() }
-    }
-
-    private fun <T, R> testTaskSuccess(
-        createTask: MockKMatcherScope.() -> Task<T>,
-        taskResult: T,
-        expectedResult: R,
-        coLocationCall: suspend CoroutineScope.() -> R
-    ) {
-        val successTask = mockTask<T>()
-        every { createTask() } returns successTask
-
-        successTask.mockSuccess(taskResult)
-
-        assertEquals(expectedResult, runBlocking { coLocationCall() })
-    }
-
-    private fun <T, R> testTaskFailure(
-        createTask: MockKMatcherScope.() -> Task<T>,
-        expectedErrorException: Exception,
-        coLocationCall: suspend CoroutineScope.() -> R
-    ) {
-        val errorTask = mockTask<T>()
-        every { createTask() } returns errorTask
-
-        assertThrows(expectedErrorException::class.java) {
-            errorTask.mockError(expectedErrorException)
-            runBlocking { coLocationCall() }
-        }
-
-    }
-
-
-    private fun <T> Task<T>.mockSuccess(taskResult: T) {
-        every { isComplete } returns false
-        every { isCanceled } returns false
-        every { exception } returns null
-        every { result } returns taskResult
-        every { addOnCompleteListener(any()) } answers {
-            val task = self as Task<T>
-            firstArg<OnCompleteListener<T>>().onComplete(task)
-            task
-        }
-        every { addOnSuccessListener(any()) } answers {
-            firstArg<OnSuccessListener<T>>().onSuccess(taskResult)
-            self as Task<T>
-        }
-    }
-
-
-    private fun <E : Exception, T> Task<T>.mockError(e: E) {
-        every { isComplete } returns false
-        every { exception } returns e
-        every { addOnCompleteListener(any()) } answers {
-            val task = self as Task<T>
-            firstArg<OnCompleteListener<T>>().onComplete(task)
-            task
-        }
-        every { addOnFailureListener(any()) } answers {
-            firstArg<OnFailureListener>().onFailure(e)
-            self as Task<T>
-        }
-    }
-
-    private fun <T> Task<T>.mockCanceled() {
-        every { isComplete } returns false
-        every { isCanceled } returns true
-        every { exception } returns null
-        every { addOnCompleteListener(any()) } answers {
-            val task = self as Task<T>
-            firstArg<OnCompleteListener<T>>().onComplete(task)
-            task
-        }
-        every { addOnCanceledListener(any()) } answers {
-            firstArg<OnCanceledListener>().onCanceled()
-            self as Task<T>
-        }
-    }
-
-    private fun <T> mockTask() = mockk<Task<T>>().apply {
-        every { addOnSuccessListener(any()) } returns this
-        every { addOnCanceledListener(any()) } returns this
-        every { addOnFailureListener(any()) } returns this
-    }
-
-    private suspend fun CapturingSlot<*>.waitForCapture() {
-        while (!isCaptured) {
-            delay(1)
-        }
-    }
-
-    class TestException : Exception()
 }

--- a/library/src/test/java/com/patloew/colocation/ResolvableApiExceptionWrapperTest.kt
+++ b/library/src/test/java/com/patloew/colocation/ResolvableApiExceptionWrapperTest.kt
@@ -1,0 +1,70 @@
+package com.patloew.colocation
+
+import android.app.Activity
+import android.app.PendingIntent
+import io.mockk.every
+import com.huawei.hms.common.ResolvableApiException as HmsResolvableApiException
+import com.google.android.gms.common.api.ResolvableApiException as GmsResolvableApiException
+import io.mockk.mockk
+import io.mockk.verifyOrder
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.assertThrows
+import java.util.concurrent.TimeUnit
+
+@Timeout(5, unit = TimeUnit.SECONDS)
+class ResolvableApiExceptionWrapperTest {
+
+    @Test
+    fun throwsOnWrongException() {
+        assertThrows<IllegalArgumentException> {
+            ResolvableApiExceptionWrapper(NullPointerException())
+        }
+    }
+
+    @Test
+    fun getResolutionIntentReturnsNull() {
+        val gmsException: GmsResolvableApiException = mockk()
+        val wrapper = ResolvableApiExceptionWrapper(gmsException)
+        assertNull(wrapper.getResolutionIntent())
+    }
+
+    @Test
+    fun startResolutionForResultIsCalled() {
+        val testActivity: Activity = mockk(relaxed = true)
+        val testRequestCode = 565
+
+        val gmsException: GmsResolvableApiException = mockk(relaxed = true)
+        val hmsException: HmsResolvableApiException = mockk(relaxed = true)
+
+        val gmsWrapper = ResolvableApiExceptionWrapper(gmsException)
+        val hmsWrapper = ResolvableApiExceptionWrapper(hmsException)
+
+        gmsWrapper.startResolutionForResult(testActivity, testRequestCode)
+        hmsWrapper.startResolutionForResult(testActivity, testRequestCode)
+
+        verifyOrder {
+            gmsException.startResolutionForResult(testActivity, testRequestCode)
+            hmsException.startResolutionForResult(testActivity, testRequestCode)
+        }
+    }
+
+    @Test
+    fun getResolutionReturnsValue() {
+        val testResolution: PendingIntent = mockk()
+        val gmsException: GmsResolvableApiException = mockk {
+            every { resolution } returns testResolution
+        }
+        val hmsException: HmsResolvableApiException = mockk {
+            every { resolution } returns testResolution
+        }
+
+        val gmsWrapper = ResolvableApiExceptionWrapper(gmsException)
+        val hmsWrapper = ResolvableApiExceptionWrapper(hmsException)
+
+        assertEquals(gmsWrapper.getResolution(), testResolution)
+        assertEquals(hmsWrapper.getResolution(), testResolution)
+    }
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,13 +2,14 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     defaultConfig {
         applicationId "com.patloew.rxlocationsample"
-        minSdkVersion 14
-        targetSdkVersion 22
+        minSdkVersion 19
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0.0"
+        multiDexEnabled true
     }
     buildTypes {
         release {
@@ -46,6 +47,8 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.3.1"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.3.1"
     implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
+
+    implementation "androidx.multidex:multidex:2.0.1"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.10"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0"

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/sample/src/main/java/com/patloew/colocationsample/MainActivity.kt
+++ b/sample/src/main/java/com/patloew/colocationsample/MainActivity.kt
@@ -19,6 +19,7 @@ import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.LibsBuilder
 import com.patloew.colocation.CoGeocoder
 import com.patloew.colocation.CoLocation
+import com.patloew.colocation.LocationServicesSource
 import java.text.DateFormat
 import java.util.Date
 

--- a/sample/src/main/java/com/patloew/colocationsample/MainViewModel.kt
+++ b/sample/src/main/java/com/patloew/colocationsample/MainViewModel.kt
@@ -4,9 +4,9 @@ import android.location.Address
 import android.location.Location
 import android.util.Log
 import androidx.lifecycle.*
-import com.google.android.gms.location.LocationRequest
 import com.patloew.colocation.CoGeocoder
 import com.patloew.colocation.CoLocation
+import com.patloew.colocation.request.LocationRequest
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect


### PR DESCRIPTION
Separate CoLocation into two implementations:
 1. `CoLocationGms` - GMS implementation
 2. `CoLocationHms` - HMS implementation

Let the `CoLocation.from` decide which `locationServicesSource` to use:
when both GMS and HMS are available then use the GMS.

Create `LocationRequest` and `LocationSettingsRequest` which are wrappers
to the platform related classes and use them to define requests without
using specific (GMS/HMS) classes.

Change the minSdkVersion to 19 (HMS requirement).

Create separate tests for both tools.